### PR TITLE
Add PyPI badge

### DIFF
--- a/src/README.rst
+++ b/src/README.rst
@@ -2,6 +2,9 @@
 django-forcedfields
 ###################
 
+.. image:: https://img.shields.io/pypi/v/django-forcedfields.svg
+   :target: https://pypi.python.org/pypi/django-forcedfields
+
 *******
 Summary
 *******


### PR DESCRIPTION
Looks like this:

<img width="856" alt="cursor_and_django-forcedfields_readme_rst_at_60b5366e4a91846d300816c06f14d50a23e97e62_ _simonw_django-forcedfields" src="https://user-images.githubusercontent.com/9599/28848820-391d13c2-76c9-11e7-8a54-b591481e00df.png">
